### PR TITLE
dvbci: add proper date time response (#833)

### DIFF
--- a/lib/dvb_ci/dvbci_datetimemgr.cpp
+++ b/lib/dvb_ci/dvbci_datetimemgr.cpp
@@ -3,6 +3,13 @@
 #include <lib/base/eerror.h>
 #include <lib/dvb_ci/dvbci_datetimemgr.h>
 
+eDVBCIDateTimeSession::eDVBCIDateTimeSession():
+	m_timer(eTimer::create(eApp)), m_interval(0)
+{
+	//CONNECT(m_timer->timeout, eDVBCIDateTimeSession::sendDateTime);
+	m_timer->timeout.connect(SigC::slot(*this, &eDVBCIDateTimeSession::sendDateTime));
+}
+
 int eDVBCIDateTimeSession::receivedAPDU(const unsigned char *tag,const void *data, int len)
 {
 	eDebugNoNewLineStart("SESSION(%d)/DATETIME %02x %02x %02x: ", session_nb, tag[0],tag[1], tag[2]);
@@ -15,6 +22,8 @@ int eDVBCIDateTimeSession::receivedAPDU(const unsigned char *tag,const void *dat
 		switch (tag[2])
 		{
 		case 0x40:
+			m_timer->stop();
+			m_interval = (data && len) ? ((unsigned char *)data)[0] : 0;
 			state=stateSendDateTime;
 			return 1;
 			break;
@@ -33,15 +42,39 @@ int eDVBCIDateTimeSession::doAction()
 	case stateStarted:
 		return 0;
 	case stateSendDateTime:
-	{
-		unsigned char tag[3]={0x9f, 0x84, 0x41}; // date_time_response
-		unsigned char msg[7]={0, 0, 0, 0, 0, 0, 0};
-		sendAPDU(tag, msg, 7);
+		sendDateTime();
 		return 0;
-	}
 	case stateFinal:
 		eDebug("stateFinal und action! kann doch garnicht sein ;)");
 	default:
 		return 0;
+	}
+}
+
+void eDVBCIDateTimeSession::sendDateTime()
+{
+	unsigned char tag[3]={0x9f, 0x84, 0x41}; // date_time_response
+	unsigned char msg[6];
+	time_t tv = time(NULL); // TODO maybe move unixtime to dvbtime in lib/dvb/dvbtime
+	uint16_t mjd = tv / 86400 + 40587; // mjd 01.01.1970 is 40587
+	tv %= 86400;
+	uint8_t hh = tv / 3600;
+	tv %= 3600;
+	uint8_t mm = tv / 60;
+	tv %= 60;
+	uint8_t ss = tv;
+
+	msg[0] = 5; // not using offset
+	msg[1] = (mjd >> 8) & 0xff;
+	msg[2] = mjd & 0xff;
+	msg[3] = ((hh / 10) << 4) | (hh % 10);
+	msg[4] = ((mm / 10) << 4) | (mm % 10);
+	msg[5] = ((ss / 10) << 4) | (ss % 10);
+
+	sendAPDU(tag, msg, 6);
+
+	if (m_interval > 0)
+	{
+		m_timer->startLongTimer(m_interval);
 	}
 }

--- a/lib/dvb_ci/dvbci_datetimemgr.h
+++ b/lib/dvb_ci/dvbci_datetimemgr.h
@@ -3,14 +3,20 @@
 
 #include <lib/dvb_ci/dvbci_session.h>
 
-class eDVBCIDateTimeSession: public eDVBCISession
+class eDVBCIDateTimeSession: public eDVBCISession, public Object
 {
 	enum {
 		stateFinal=statePrivate, stateSendDateTime
 	};
+
+	ePtr<eTimer> m_timer;
+	int m_interval;
+
 	int receivedAPDU(const unsigned char *tag, const void *data, int len);
 	int doAction();
 public:
+	eDVBCIDateTimeSession();
+	void sendDateTime();
 };
 
 #endif


### PR DESCRIPTION
That commit fixes the missing datetime response on CI.

Same function as implemented by en50221 code, supporting also offset.

int en50221_app_datetime_send(struct en50221_app_datetime *datetime,
			      uint16_t session_number,
			      time_t utc_time, int time_offset)
{
	uint8_t data[11];
	int data_length;

	data[0] = (TAG_DATE_TIME >> 16) & 0xFF;
	data[1] = (TAG_DATE_TIME >> 8) & 0xFF;
	data[2] = TAG_DATE_TIME & 0xFF;
	if (time_offset != -1) {
		data[3] = 7;
		unixtime_to_dvbdate(utc_time, data + 4);
		data[9] = time_offset >> 8;
		data[10] = time_offset;
		data_length = 11;
	} else {
		data[3] = 5;
		unixtime_to_dvbdate(utc_time, data + 4);
		data_length = 9;
	}
	return datetime->funcs->send_data(datetime->funcs->arg,
					  session_number, data,
					  data_length);
}

The CONNECT macro was failing to work, instead SigC::slot used directly.